### PR TITLE
Implement client reconnections and majoritari start

### DIFF
--- a/src/area.c
+++ b/src/area.c
@@ -104,6 +104,16 @@ void c_area_update(size_t ngroups, tileblock_t *tileblock) {
 }
 
 void draw_area() {
+    if (levels_count == 0) { /* Before START_GAME */
+        mvwprintw(W(W_AREA), 1, 1, "%s", _("Connected players:"));
+        for (size_t i = 0; i < players_len; i++) {
+            mvwaddch(W(W_AREA), 2 + i, 1, players[i].ready ? '+' : '-');
+            mvwprintw(W(W_AREA), 2 + i, 3, "%s", players[i].nickname);
+            mvwprintw(W(W_AREA), windows[W_AREA].max_y - 2, 1, "%s",
+                    _("Write !start or !s to chat to begin"));
+        }
+    }
+
     if (c_curr == NULL) {
         return;
     }

--- a/src/client.c
+++ b/src/client.c
@@ -78,7 +78,6 @@ void* worker() {
             continue;
         }
 
-
         if ((rc = readall(sock, &mbuf.msg, sizeof(mbuf.msg))) == 0) {
             server_connected = 0;
             // TODO implement dialog with this message:
@@ -100,6 +99,9 @@ void* worker() {
                 break;
             case MSG_PUT_AREA:
                 logger("[C] [PUT_AREA]");
+                break;
+            case MSG_PUT_PLAYERS_FULL:
+                logger("[C] [PUT_PLAYERS_FULL]");
                 break;
             case MSG_PUT_PLAYERS:
                 logger("[C] [PUT_PLAYERS]");
@@ -145,6 +147,12 @@ void* worker() {
                 break;
             case MSG_PUT_AREA:
                 c_area_update(1, (tileblock_t *)payload);
+
+                free(payload);
+
+                break;
+            case MSG_PUT_PLAYERS_FULL:
+                c_receive_players_full((players_full_mbuf_t *)payload);
 
                 free(payload);
 

--- a/src/levels.h
+++ b/src/levels.h
@@ -23,4 +23,6 @@ void s_levels_init();
 void s_level_send(size_t level, player_t *player);
 void s_area_send(size_t level, player_t *player);
 
+extern size_t levels_count;
+
 #endif /* LEVELS_H */

--- a/src/player.h
+++ b/src/player.h
@@ -4,13 +4,15 @@
 
 #include "itmmorgue.h"
 
-#define MAX_PLAYERS 3
+#define MAX_PLAYERS 5
 
 typedef struct player {
     enum colors color;          // server-specified attributes
     uint16_t y;                 // absolute Y
     uint16_t x;                 // absolute X
     char nickname[PLAYER_NAME_MAXLEN];
+    uint8_t ready;
+    uint8_t connected;
     connection_t *connection;
     /* inventory_t */
     /* common creatures stats_t */
@@ -19,24 +21,33 @@ typedef struct player {
     /* skills_t */
 } player_t;
 
+typedef struct players_full_mbuf {
+    player_t players[MAX_PLAYERS];
+    uint8_t self;
+    size_t players_len;
+} players_full_mbuf_t;
+
 typedef struct players_mbuf {
     struct c_player {
         enum colors color;
         uint16_t y;
         uint16_t x;
     } players[MAX_PLAYERS];
-    char self;
+    uint8_t self;
     size_t players_len;
 } players_mbuf_t;
 
 size_t player_init(enum colors color, char *nickname,
         connection_t *connection);
 void c_receive_players(players_mbuf_t *mbuf);
+void c_receive_players_full(players_full_mbuf_t *mbuf);
+void s_send_players_full(player_t *player);
 void s_send_players(player_t *player);
 void c_send_move(enum keyboard last_key);
 
 extern player_t players[];
 extern size_t players_len;
 extern size_t player_self;
+extern size_t players_total;
 
 #endif /* PLAYER_H */

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -23,7 +23,7 @@ void mqueue_put(mqueue_t *queue, mbuf_t mbuf) {
         if (EDEADLK == rc) {
             panic("Message queue: deadlock!");
         }
-        panic("Message queue: failure during mutex locking");
+        panic("[put] Message queue: failure during mutex locking");
     }
 
     size_t pos = queue->start_position;
@@ -56,7 +56,7 @@ int mqueue_get(mqueue_t *queue, mbuf_t *mbuf) {
         if (EDEADLK == rc) {
             panic("Message queue: deadlock!");
         }
-        panic("Message queue: failure during mutex locking");
+        panic("[get] Message queue: failure during mutex locking");
     }
 
     if (queue->size == 0) {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -22,6 +22,8 @@ typedef struct msg {
         MSG_REPORT_NICKNAME,  // c2s user nickname notification
         MSG_ERROR_NICKNAME,   // s2c incorrect nickname provided
 
+        MSG_START_GAME,       // c2s let the battle begin
+
         MSG_PUT_LEVEL,        // s2c level transmission
         MSG_PUT_AREA,         // s2c area transmission
 
@@ -32,7 +34,8 @@ typedef struct msg {
         MSG_PUT_SYSMSG,       // s2c sysmsg history update
         MSG_SUBSCRIBE_SYSMSG, // c2s sysmsg subscription mask
 
-        MSG_PUT_PLAYERS,      // s2c players[] transmission
+        MSG_PUT_PLAYERS,      // s2c players[color, y, x] transmission
+        MSG_PUT_PLAYERS_FULL, // s2c players[...] transmission
         MSG_MOVE_PLAYER,      // c2s send player's move
 
         MSG_PUT_STATUS,       // s2c player status update

--- a/src/server.h
+++ b/src/server.h
@@ -17,4 +17,14 @@ void server_fork_start();
 
 void* process_client(connection_t *connection);
 
+/*
+ * Global game state. 
+ * 0 = new game, never played
+ * 1 = game created, populating players with areas
+ * 2 = normal game state
+ * 3 = resurrection phase
+ * 4 = resurrected by nickname, needs to be repopulated
+ */
+extern char start;
+
 #endif /* SERVER_H */


### PR DESCRIPTION
Я тут один небольшой коммит сделал...
Вкратце: чтобы попасть в игру, нужно ввести в чатик "!s" или "!start".
После этого новые псы уже подключиться к игре не смогут. Будут терять коннекции к серверу и оставаться в главной менюхе.
Если же кто-то из клиентов отключится, то на карте изменится его цвет и снова можно будет подключиться к серверу. 
Желательно, чтобы @ValeriyKr внимательно прочитал код. Хоть я его потестил. В местах, где нет TODO, он даже вроде рабтает.